### PR TITLE
Fix dataset conversion utilities

### DIFF
--- a/imitation/common/dataset.py
+++ b/imitation/common/dataset.py
@@ -14,40 +14,30 @@ DATA_DIR = Path(os.environ["DATA_DIR"]) if "DATA_DIR" in os.environ else None
 CODEBASE_VERSION = "v1.4"
 
 def hf_transform_to_torch(items_dict):
-    from PIL import Image
+    """Convert items from the HuggingFace dataset to PyTorch tensors."""
     import io
-    for key in items_dict:
-        first_item = items_dict[key][0]
-        
-        if key == 'observation.image':
-            first_item = items_dict[key][0]['bytes']
-            # print(first_item)
-            # print('------------')
-            first_item = Image.open(io.BytesIO(first_item))
+    import ast
+    from PIL import Image
 
-           
-        if isinstance(first_item, PILImage.Image):
-            to_tensor = transforms.ToTensor()
-            for item in items_dict[key]:
-                
-                item = item['bytes']
-                items_dict[key] = to_tensor(Image.open(io.BytesIO(item)))
-                items_dict[key] = items_dict[key].unsqueeze(0)
-                
-                
-        elif key == 'observation.state' or key == 'action':
-                import numpy as np
-                for next_line  in items_dict[key]:
-                    next_line = next_line[1:-1].split(',')
-                    next_line = [float(item) for item in next_line]
-                    next_line = np.array(next_line)
+    # observation.image is stored as bytes. Convert to a (C, H, W) tensor.
+    img_bytes = items_dict["observation.image"]["bytes"]
+    img = Image.open(io.BytesIO(img_bytes))
+    items_dict["observation.image"] = transforms.ToTensor()(img)
 
-                    items_dict[key] = torch.tensor(next_line, dtype=torch.float32)
-                    items_dict[key] = items_dict[key].unsqueeze(0)
-        else:
+    # observation.state and action are stored as string representations of lists.
+    items_dict["observation.state"] = torch.tensor(
+        ast.literal_eval(items_dict["observation.state"]), dtype=torch.float32
+    )
+    items_dict["action"] = torch.tensor(
+        ast.literal_eval(items_dict["action"]), dtype=torch.float32
+    )
 
-            items_dict[key] = torch.tensor(items_dict[key])
-            
+    # Convert all remaining fields directly to tensors.
+    for key, value in list(items_dict.items()):
+        if key in {"observation.image", "observation.state", "action"}:
+            continue
+        items_dict[key] = torch.tensor(value)
+
     return items_dict
 
 

--- a/imitation/compute_stats
+++ b/imitation/compute_stats
@@ -158,35 +158,27 @@ from datasets import load_dataset
 from torchvision import transforms
 
 def hf_transform_to_torch(items_dict):
-    from PIL import Image
+    """Convert items from the HuggingFace dataset to PyTorch tensors."""
     import io
-    for key in items_dict:
-        first_item = items_dict[key][0]
-        if key == 'observation.image':
-            first_item = items_dict[key][0]['bytes']
-            first_item = Image.open(io.BytesIO(first_item))
+    import ast
+    from PIL import Image
 
-           
-        if isinstance(first_item, PILImage.Image):
-            to_tensor = transforms.ToTensor()
-            for item in items_dict[key]:
-                item = item['bytes']
-                items_dict[key] = to_tensor(Image.open(io.BytesIO(item)))
-                items_dict[key] = items_dict[key].unsqueeze(0)
-                
-        elif key == 'observation.state' or key == 'action':
-                import numpy as np
-                for next_line  in items_dict[key]:
-                    next_line = next_line[1:-1].split(',')
-                    next_line = [float(item) for item in next_line]
-                    next_line = np.array(next_line)
+    img_bytes = items_dict["observation.image"]["bytes"]
+    img = Image.open(io.BytesIO(img_bytes))
+    items_dict["observation.image"] = transforms.ToTensor()(img)
 
-                    items_dict[key] = torch.tensor(next_line, dtype=torch.float32)
-                    items_dict[key] = items_dict[key].unsqueeze(0)
-        else:
+    items_dict["observation.state"] = torch.tensor(
+        ast.literal_eval(items_dict["observation.state"]), dtype=torch.float32
+    )
+    items_dict["action"] = torch.tensor(
+        ast.literal_eval(items_dict["action"]), dtype=torch.float32
+    )
 
-            items_dict[key] = torch.tensor(items_dict[key]) #[torch.tensor(x) for x in items_dict[key]]
-            
+    for key, value in list(items_dict.items()):
+        if key in {"observation.image", "observation.state", "action"}:
+            continue
+        items_dict[key] = torch.tensor(value)
+
     return items_dict
 
 


### PR DESCRIPTION
## Summary
- fix `hf_transform_to_torch` in dataset utilities and stats script

## Testing
- `PYTHONPATH=. python imitation/compute_stats --path imitation/data/real_env_data.parquet` *(fails: ModuleNotFoundError: No module named 'einops')*
- `PYTHONPATH=. python - <<'PY'
from imitation.common.dataset import LeRobotDataset
LeRobotDataset('test', root='imitation/data/real_env_data.parquet')
PY` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6840ac3479208333b2f7f888a03db579