### PR TITLE
Fix dataset conversion utilities

### DIFF
--- a/imitation/compute_stats
+++ b/imitation/compute_stats
@@ -158,35 +158,43 @@ from datasets import load_dataset
 from torchvision import transforms
 
 def hf_transform_to_torch(items_dict):
-    from PIL import Image
+    """Convert items from the HuggingFace dataset to PyTorch tensors."""
     import io
-    for key in items_dict:
-        first_item = items_dict[key][0]
-        if key == 'observation.image':
-            first_item = items_dict[key][0]['bytes']
-            first_item = Image.open(io.BytesIO(first_item))
+    import ast
+    from PIL import Image
 
-           
-        if isinstance(first_item, PILImage.Image):
-            to_tensor = transforms.ToTensor()
-            for item in items_dict[key]:
-                item = item['bytes']
-                items_dict[key] = to_tensor(Image.open(io.BytesIO(item)))
-                items_dict[key] = items_dict[key].unsqueeze(0)
-                
-        elif key == 'observation.state' or key == 'action':
-                import numpy as np
-                for next_line  in items_dict[key]:
-                    next_line = next_line[1:-1].split(',')
-                    next_line = [float(item) for item in next_line]
-                    next_line = np.array(next_line)
+    batched = isinstance(items_dict["observation.image"], list)
 
-                    items_dict[key] = torch.tensor(next_line, dtype=torch.float32)
-                    items_dict[key] = items_dict[key].unsqueeze(0)
-        else:
+    if batched:
+        images, states, actions = [], [], []
+        for img_dict, state_str, action_str in zip(
+            items_dict["observation.image"], items_dict["observation.state"], items_dict["action"]
+        ):
+            img = Image.open(io.BytesIO(img_dict["bytes"]))
+            images.append(transforms.ToTensor()(img))
+            states.append(torch.tensor(ast.literal_eval(state_str), dtype=torch.float32))
+            actions.append(torch.tensor(ast.literal_eval(action_str), dtype=torch.float32))
+        items_dict["observation.image"] = images
+        items_dict["observation.state"] = states
+        items_dict["action"] = actions
+        for key, value in list(items_dict.items()):
+            if key in {"observation.image", "observation.state", "action"}:
+                continue
+            items_dict[key] = [torch.tensor(v) for v in value]
+    else:
+        img = Image.open(io.BytesIO(items_dict["observation.image"]["bytes"]))
+        items_dict["observation.image"] = transforms.ToTensor()(img)
+        items_dict["observation.state"] = torch.tensor(
+            ast.literal_eval(items_dict["observation.state"]), dtype=torch.float32
+        )
+        items_dict["action"] = torch.tensor(
+            ast.literal_eval(items_dict["action"]), dtype=torch.float32
+        )
+        for key, value in list(items_dict.items()):
+            if key in {"observation.image", "observation.state", "action"}:
+                continue
+            items_dict[key] = torch.tensor(value)
 
-            items_dict[key] = torch.tensor(items_dict[key]) #[torch.tensor(x) for x in items_dict[key]]
-            
     return items_dict
 
 


### PR DESCRIPTION
## Summary
- fix hf_transform_to_torch to correctly handle batched inputs
- guard episode index computation against transforms

## Testing
- `PYTHONPATH=imitation python - <<'PY'
from common.dataset import LeRobotDataset
print(len(LeRobotDataset('test', root='imitation/data/real_env_data.parquet')))
PY`
- `PYTHONPATH=imitation python imitation/compute_stats --path imitation/data/real_env_data.parquet` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6840ac3479208333b2f7f888a03db579